### PR TITLE
LeavingReason を削除

### DIFF
--- a/Runtime/MultiplayClient.cs
+++ b/Runtime/MultiplayClient.cs
@@ -40,7 +40,7 @@ namespace Extreal.Integration.Multiplay.Messaging
         /// <para>Invokes just before this client leaves a group.</para>
         /// Arg: reason why this client leaves.
         /// </summary>
-        public IObservable<string> OnLeaving => MessagingClient.OnLeaving;
+        public IObservable<Unit> OnLeaving => MessagingClient.OnLeaving;
 
         /// <summary>
         /// <para>Invokes immediately after this client unexpectedly leaves a group.</para>
@@ -139,7 +139,7 @@ namespace Extreal.Integration.Multiplay.Messaging
                 .AddTo(disposables);
 
             MessagingClient.OnLeaving
-                .Merge(MessagingClient.OnUnexpectedLeft)
+                .Merge(MessagingClient.OnUnexpectedLeft.Select(_ => Unit.Default))
                 .Subscribe(_ => Clear())
                 .AddTo(disposables);
 

--- a/Tests/Runtime/MultiplayClientTest.cs
+++ b/Tests/Runtime/MultiplayClientTest.cs
@@ -44,7 +44,7 @@ namespace Extreal.Integration.Multiplay.Messaging.Test
                 .AddTo(disposables);
 
             multiplayClient.OnLeaving
-                .Subscribe(eventHandler.SetLeavingReason)
+                .Subscribe(_ => eventHandler.SetLeavingReason(true))
                 .AddTo(disposables);
 
             multiplayClient.OnUnexpectedLeft
@@ -155,9 +155,9 @@ namespace Extreal.Integration.Multiplay.Messaging.Test
         [UnityTest]
         public IEnumerator LeaveSuccess() => UniTask.ToCoroutine(async () =>
         {
-            Assert.That(eventHandler.LeavingReason, Is.Null);
+            Assert.That(eventHandler.IsLeaving, Is.False);
             await multiplayClient.LeaveAsync();
-            Assert.That(eventHandler.LeavingReason, Is.EqualTo("leave request"));
+            Assert.That(eventHandler.IsLeaving, Is.True);
         });
 
         [Test]
@@ -435,9 +435,9 @@ namespace Extreal.Integration.Multiplay.Messaging.Test
             public void SetClientId(string clientId)
                 => ClientId = clientId;
 
-            public string LeavingReason { get; private set; }
-            public void SetLeavingReason(string reason)
-                => LeavingReason = reason;
+            public bool IsLeaving { get; private set; }
+            public void SetLeavingReason(bool isLeaving)
+                => IsLeaving = isLeaving;
 
             public string UnexpectedLeftReason { get; private set; }
             public void SetUnexpectedLeftReason(string reason)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.co.tis.extreal.integration.multiplay.messaging",
-  "version": "1.0.0-next.4",
+  "version": "1.0.0-next.5",
   "displayName": "Extreal.Integration.Multiplay.Messaging",
   "unity": "2022.3",
   "author": {
@@ -11,6 +11,6 @@
     "com.neuecc.unirx": "7.1.0",
     "jp.co.tis.extreal.core.logging": "1.2.0",
     "jp.co.tis.extreal.core.common": "1.2.0-next.1",
-    "jp.co.tis.extreal.integration.messaging": "1.0.0-next.3"
+    "jp.co.tis.extreal.integration.messaging": "1.0.0-next.4"
   }
 }


### PR DESCRIPTION
# 何の変更を加えましたか？

- LeavingReason を削除しました
  - 固定文字列を返していたため
- `Messaging` のバージョンを上げました

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました
    - サンプルはなし

## 変更影響

https://github.com/extreal-dev/Extreal.Guide/pull/56
- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [ ] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました

# レビュアーへのメッセージ
