### PR TITLE
Newtonsoft.Json への参照を package.json に追加

### DIFF
--- a/Tests/Runtime/MultiplayClientTest.cs
+++ b/Tests/Runtime/MultiplayClientTest.cs
@@ -289,7 +289,7 @@ namespace Extreal.Integration.Multiplay.Messaging.Test
             await multiplayClient.JoinAsync(joiningConfig);
 
             var spawnedObject = multiplayClient.SpawnObject(networkObjectsProvider.NetworkObject);
-            await AssertLogAppearsInSomeFramesAsync($"\"Command\":{(int)MultiplayMessageCommand.Update}", LogType.Log);
+            await AssertLogAppearsInSomeFramesAsync($"\"Command\":{(int)MultiplayMessageCommand.Update}", LogType.Log, 60);
         });
 
         [UnityTest]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "com.cysharp.unitask": "2.5.0",
     "com.neuecc.unirx": "7.1.0",
+    "com.unity.nuget.newtonsoft-json": "3.2.1",
     "jp.co.tis.extreal.core.logging": "1.2.0",
     "jp.co.tis.extreal.core.common": "1.2.0-next.1",
     "jp.co.tis.extreal.integration.messaging": "1.0.0-next.4"


### PR DESCRIPTION
# 何の変更を加えましたか？

- Newtonsoft.Json への参照を package.json に追加しました
- 失敗したテストを修正しました

# 何を確認しましたか?

## 実装

参照方法の変更のみのため以下は未確認
- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

https://github.com/extreal-dev/Extreal.Guide/pull/76
- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] 後方互換が崩れている場合はGuideのReleaseページのUpgrade guideに対応方法が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました

# レビュアーへのメッセージ
